### PR TITLE
Fix static path and update user test

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -131,7 +131,12 @@ if settings.BACKEND_CORS_ORIGINS:
 #########################################################
 # Montage des fichiers statiques
 #########################################################
-app.mount("/static", StaticFiles(directory="static"), name="static")
+from pathlib import Path
+
+# Utilise un chemin absolu pour le dossier static afin d'eviter les erreurs
+# lors de l'execution depuis un autre repertoire que backend
+static_dir = Path(__file__).resolve().parent.parent / "static"
+app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 #########################################################
 
 

--- a/backend/app/test/api/test_users.py
+++ b/backend/app/test/api/test_users.py
@@ -1,4 +1,11 @@
 from fastapi.testclient import TestClient
+from pathlib import Path
+import sys
+
+# Ajoute le dossier contenant le code de l'application au PYTHONPATH pour les tests
+# On ajoute le dossier "backend" afin que le package "app" soit importable
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
 from app.main import app
 
 client = TestClient(app)
@@ -15,6 +22,7 @@ def test_register_user():
     )
     assert response.status_code == 201
     data = response.json()
-    assert "user_id" in data
-    assert "message" in data
+    assert data["status"] == "success"
+    assert data["code"] == 201
     assert data["message"] == "Utilisateur créé avec succès"
+    assert "user_id" in data["data"]


### PR DESCRIPTION
## Summary
- correct static files path in `main.py`
- make test importable and validate normalized API response

## Testing
- `flake8`
- `pytest backend/app/test/api/test_users.py::test_register_user -q` *(fails: OperationalError - could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6841641a8cd88331936054a3081f06bd